### PR TITLE
refactor(api): rename 'CommandArgsOverrides' to 'CliOverrides'

### DIFF
--- a/api/v1alpha1/dolphinschedulercluster_types.go
+++ b/api/v1alpha1/dolphinschedulercluster_types.go
@@ -171,7 +171,7 @@ type RoleSpec struct {
 	PodDisruptionBudget *commonsv1alpha1.PodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	CommandOverrides []string `json:"commandOverrides,omitempty"`
+	CliOverrides []string `json:"cliOverrides,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	ConfigOverrides *ConfigOverridesSpec `json:"configOverrides,omitempty"`
@@ -195,7 +195,7 @@ type RoleGroupSpec struct {
 	PodDisruptionBudget *commonsv1alpha1.PodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	CommandOverrides []string `json:"commandOverrides,omitempty"`
+	CliOverrides []string `json:"cliOverrides,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	ConfigOverrides *ConfigOverridesSpec `json:"configOverrides,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -338,8 +338,8 @@ func (in *RoleGroupSpec) DeepCopyInto(out *RoleGroupSpec) {
 		*out = new(commonsv1alpha1.PodDisruptionBudgetSpec)
 		**out = **in
 	}
-	if in.CommandOverrides != nil {
-		in, out := &in.CommandOverrides, &out.CommandOverrides
+	if in.CliOverrides != nil {
+		in, out := &in.CliOverrides, &out.CliOverrides
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
@@ -387,8 +387,8 @@ func (in *RoleSpec) DeepCopyInto(out *RoleSpec) {
 		*out = new(commonsv1alpha1.PodDisruptionBudgetSpec)
 		**out = **in
 	}
-	if in.CommandOverrides != nil {
-		in, out := &in.CommandOverrides, &out.CommandOverrides
+	if in.CliOverrides != nil {
+		in, out := &in.CliOverrides, &out.CliOverrides
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crd/bases/dolphinscheduler.zncdata.dev_dolphinschedulerclusters.yaml
+++ b/config/crd/bases/dolphinscheduler.zncdata.dev_dolphinschedulerclusters.yaml
@@ -43,7 +43,7 @@ spec:
             properties:
               alerter:
                 properties:
-                  commandOverrides:
+                  cliOverrides:
                     items:
                       type: string
                     type: array
@@ -1148,7 +1148,7 @@ spec:
                   roleGroups:
                     additionalProperties:
                       properties:
-                        commandOverrides:
+                        cliOverrides:
                           items:
                             type: string
                           type: array
@@ -2270,7 +2270,7 @@ spec:
                 type: object
               api:
                 properties:
-                  commandOverrides:
+                  cliOverrides:
                     items:
                       type: string
                     type: array
@@ -3375,7 +3375,7 @@ spec:
                   roleGroups:
                     additionalProperties:
                       properties:
-                        commandOverrides:
+                        cliOverrides:
                           items:
                             type: string
                           type: array
@@ -4661,7 +4661,7 @@ spec:
                 type: object
               master:
                 properties:
-                  commandOverrides:
+                  cliOverrides:
                     items:
                       type: string
                     type: array
@@ -5766,7 +5766,7 @@ spec:
                   roleGroups:
                     additionalProperties:
                       properties:
-                        commandOverrides:
+                        cliOverrides:
                           items:
                             type: string
                           type: array
@@ -6888,7 +6888,7 @@ spec:
                 type: object
               worker:
                 properties:
-                  commandOverrides:
+                  cliOverrides:
                     items:
                       type: string
                     type: array
@@ -7993,7 +7993,7 @@ spec:
                   roleGroups:
                     additionalProperties:
                       properties:
-                        commandOverrides:
+                        cliOverrides:
                           items:
                             type: string
                           type: array

--- a/internal/common/resource.go
+++ b/internal/common/resource.go
@@ -38,7 +38,7 @@ func CreateDeploymentReconciler(
 			Annotations:   roleGroupInfo.GetAnnotations(),
 		},
 		// PodOverrides:     mergedCfg.PodOverrides,
-		CommandOverrides: mergedCfg.CommandOverrides,
+		CommandOverrides: mergedCfg.CliOverrides,
 		EnvOverrides:     mergedCfg.EnvOverrides,
 	}
 	return NewDeploymentReconciler(ctx, mergedCfg, client, stopped, image, options, roleGroupInfo, []corev1.Container{*container}, volumes)
@@ -68,7 +68,7 @@ func CreateStatefulSetReconciler(
 			Annotations:   roleGroupInfo.GetAnnotations(),
 		},
 		// PodOverrides:     mergedCfg.PodOverrides,
-		CommandOverrides: mergedCfg.CommandOverrides,
+		CommandOverrides: mergedCfg.CliOverrides,
 		EnvOverrides:     mergedCfg.EnvOverrides,
 	}
 


### PR DESCRIPTION
References https://github.com/zncdatadev/trino-operator/issues/154
