### PR TITLE
feat(pdb): add PodDisruptionBudget support

### DIFF
--- a/api/v1alpha1/dolphinschedulercluster_types.go
+++ b/api/v1alpha1/dolphinschedulercluster_types.go
@@ -168,7 +168,7 @@ type RoleSpec struct {
 	RoleGroups map[string]RoleGroupSpec `json:"roleGroups,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	PodDisruptionBudget *commonsv1alpha1.PodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`
+	RoleConfig *commonsv1alpha1.RoleConfigSpec `json:"roleConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	CliOverrides []string `json:"cliOverrides,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -382,9 +382,9 @@ func (in *RoleSpec) DeepCopyInto(out *RoleSpec) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
-	if in.PodDisruptionBudget != nil {
-		in, out := &in.PodDisruptionBudget, &out.PodDisruptionBudget
-		*out = new(commonsv1alpha1.PodDisruptionBudgetSpec)
+	if in.RoleConfig != nil {
+		in, out := &in.RoleConfig, &out.RoleConfig
+		*out = new(commonsv1alpha1.RoleConfigSpec)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.CliOverrides != nil {

--- a/config/crd/bases/dolphinscheduler.zncdata.dev_dolphinschedulerclusters.yaml
+++ b/config/crd/bases/dolphinscheduler.zncdata.dev_dolphinschedulerclusters.yaml
@@ -1132,19 +1132,22 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  podDisruptionBudget:
-                    description: |-
-                      This struct is used to configure:
-
-                      1. If PodDisruptionBudgets are created by the operator
-                      2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                  roleConfig:
                     properties:
-                      enabled:
-                        default: true
-                        type: boolean
-                      maxUnavailable:
-                        format: int32
-                        type: integer
+                      podDisruptionBudget:
+                        description: |-
+                          This struct is used to configure:
+
+                          1. If PodDisruptionBudgets are created by the operator
+                          2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                        properties:
+                          enabled:
+                            default: true
+                            type: boolean
+                          maxUnavailable:
+                            format: int32
+                            type: integer
+                        type: object
                     type: object
                   roleGroups:
                     additionalProperties:
@@ -3361,19 +3364,22 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  podDisruptionBudget:
-                    description: |-
-                      This struct is used to configure:
-
-                      1. If PodDisruptionBudgets are created by the operator
-                      2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                  roleConfig:
                     properties:
-                      enabled:
-                        default: true
-                        type: boolean
-                      maxUnavailable:
-                        format: int32
-                        type: integer
+                      podDisruptionBudget:
+                        description: |-
+                          This struct is used to configure:
+
+                          1. If PodDisruptionBudgets are created by the operator
+                          2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                        properties:
+                          enabled:
+                            default: true
+                            type: boolean
+                          maxUnavailable:
+                            format: int32
+                            type: integer
+                        type: object
                     type: object
                   roleGroups:
                     additionalProperties:
@@ -5754,19 +5760,22 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  podDisruptionBudget:
-                    description: |-
-                      This struct is used to configure:
-
-                      1. If PodDisruptionBudgets are created by the operator
-                      2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                  roleConfig:
                     properties:
-                      enabled:
-                        default: true
-                        type: boolean
-                      maxUnavailable:
-                        format: int32
-                        type: integer
+                      podDisruptionBudget:
+                        description: |-
+                          This struct is used to configure:
+
+                          1. If PodDisruptionBudgets are created by the operator
+                          2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                        properties:
+                          enabled:
+                            default: true
+                            type: boolean
+                          maxUnavailable:
+                            format: int32
+                            type: integer
+                        type: object
                     type: object
                   roleGroups:
                     additionalProperties:
@@ -7983,19 +7992,22 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  podDisruptionBudget:
-                    description: |-
-                      This struct is used to configure:
-
-                      1. If PodDisruptionBudgets are created by the operator
-                      2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                  roleConfig:
                     properties:
-                      enabled:
-                        default: true
-                        type: boolean
-                      maxUnavailable:
-                        format: int32
-                        type: integer
+                      podDisruptionBudget:
+                        description: |-
+                          This struct is used to configure:
+
+                          1. If PodDisruptionBudgets are created by the operator
+                          2. The allowed number of Pods to be unavailable (`maxUnavailable`)
+                        properties:
+                          enabled:
+                            default: true
+                            type: boolean
+                          maxUnavailable:
+                            format: int32
+                            type: integer
+                        type: object
                     type: object
                   roleGroups:
                     additionalProperties:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -87,6 +87,18 @@ rules:
   - patch
   - update
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/internal/controller/dolphinschedulercluster_controller.go
+++ b/internal/controller/dolphinschedulercluster_controller.go
@@ -62,6 +62,7 @@ type DolphinschedulerClusterReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=secrets.zncdata.dev,resources=secretclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=authentication.zncdata.dev,resources=authenticationclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/test/e2e/pdb/chainsaw-test.yaml
+++ b/test/e2e/pdb/chainsaw-test.yaml
@@ -1,0 +1,74 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: pdb
+spec:
+  bindings:
+  - name: POSTGRESQL_USERNAME
+    value: test
+  - name: POSTGRESQL_PASSWORD
+    value: test
+  steps:
+  - try:
+    - apply:
+        file: ../setup/database.yaml
+    - assert:
+        file: ../setup/database-assert.yaml
+  - try:
+    - apply:
+        file: ../setup/zookeeper.yaml
+    - assert:
+        file: ../setup/zookeeper-assert.yaml
+    catch:
+      - sleep:
+          duration: 10s
+      - script:
+          env:
+            - name: NAMESPACE
+              value: ($namespace)
+          content: |
+            set -ex
+            kubectl -n $NAMESPACE get pods
+      - describe:
+          apiVersion: v1
+          kind: Pod
+          selector: app.kubernetes.io/instance=test-zk
+      - podLogs:
+          selector: app.kubernetes.io/name=zookeeper-operator
+          tail: -1
+  - try:
+    - script:
+        content: |
+          set -ex
+          free -h
+          df -h
+  - try:
+    - apply:
+        file: dolphinscheduler.yaml
+    - assert:
+        timeout: 400s
+        file: dolphinscheduler-assert.yaml
+    - assert:
+        file: pdb-assert.yaml
+    cleanup:
+    - sleep:
+        duration: 10s
+    catch:
+      - sleep:
+          duration: 10s
+      - script:
+          env:
+            - name: NAMESPACE
+              value: ($namespace)
+          content: |
+            set -ex
+            free -h
+            df -h
+            kubectl -n $NAMESPACE get pods
+      # - describe:
+      #     apiVersion: v1
+      #     kind: Pod
+      #     selector: app.kubernetes.io/name=dolphinschedulercluster
+      # - podLogs:
+      #     selector: app.kubernetes.io/name=dolphinschedulercluster
+      #     tail: -1

--- a/test/e2e/pdb/dolphinscheduler-assert.yaml
+++ b/test/e2e/pdb/dolphinscheduler-assert.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-dolphinscheduler-master-default
+status:
+  replicas: 1
+  availableReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-dolphinscheduler-worker-default
+status:
+  replicas: 1
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-dolphinscheduler-api-default
+status:
+  replicas: 1
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-dolphinscheduler-alert-default
+status:
+  replicas: 1
+  availableReplicas: 1

--- a/test/e2e/pdb/dolphinscheduler.yaml
+++ b/test/e2e/pdb/dolphinscheduler.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: zookeeper.zncdata.dev/v1alpha1
+kind: ZookeeperZnode
+metadata:
+  name: test-znode
+spec:
+  clusterRef:
+    name: test-zk
+---
+# postgresql credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-credentials
+type: Opaque
+data:
+  username: dGVzdA==
+  password: dGVzdA==
+---
+apiVersion: dolphinscheduler.zncdata.dev/v1alpha1
+kind: DolphinschedulerCluster
+metadata:
+  name: test-dolphinscheduler
+spec:
+  clusterConfig:
+    zookeeperConfigMapName: test-znode
+    database:
+      databaseType: postgresql
+      connectionString: jdbc:postgresql://postgresql:5432/dolphinscheduler
+      credentialsSecret: postgresql-credentials
+  master:
+    roleConfig:
+      podDisruptionBudget:
+        maxUnavailable: 2
+    roleGroups:
+      default:
+        replicas: 1
+  worker:
+    roleConfig:
+      podDisruptionBudget:
+        maxUnavailable: 2
+    roleGroups:
+      default:
+        replicas: 1
+  api:
+    roleConfig:
+      podDisruptionBudget:
+        maxUnavailable: 2
+    roleGroups:
+      default:
+        replicas: 1
+  alerter:
+    roleConfig:
+      podDisruptionBudget:
+        maxUnavailable: 2
+    roleGroups:
+      default:
+        replicas: 1

--- a/test/e2e/pdb/pdb-assert.yaml
+++ b/test/e2e/pdb/pdb-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-dolphinscheduler-alert
+spec:
+  maxUnavailable: 2
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-dolphinscheduler-api
+spec:
+  maxUnavailable: 2
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-dolphinscheduler-master
+spec:
+  maxUnavailable: 2
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-dolphinscheduler-worker
+spec:
+  maxUnavailable: 2


### PR DESCRIPTION
- **fix(productlogging): logback config syntax erro**
- **test(vector): optional the elasticsearch sink in vector e2e**
- **feat(pdb): add PodDisruptionBudget support**

References: https://github.com/zncdatadev/trino-operator/issues/183

