### PR TITLE
fix: resolve Master OOMKilled and Chainsaw 1.35 test compatibility

### DIFF
--- a/internal/controller/master/role.go
+++ b/internal/controller/master/role.go
@@ -83,7 +83,7 @@ func (a *MasterRoleResourceReconcilerBuilder) ResourceReconcilers(
 			dolphinv1alpha1.MasterActualPortName: dolphinv1alpha1.MasterActualPort,
 		}).
 		WithEnvs(util.SortedMap{
-			"JAVA_OPTS":                                    "-Xms1g -Xmx1g -Xmn512m",
+			"JAVA_OPTS":                                    "-Xms512m -Xmx512m -Xmn256m",
 			"MASTER_DISPATCH_TASK_NUM":                     "3",
 			"MASTER_EXEC_TASK_NUM":                         "20",
 			"MASTER_EXEC_THREADS":                          "100",

--- a/test/e2e/default/chainsaw-test.yaml
+++ b/test/e2e/default/chainsaw-test.yaml
@@ -59,8 +59,10 @@ spec:
     - describe:
         apiVersion: v1
         kind: Pod
+        selector: app.kubernetes.io/instance=test-dolphinscheduler
     - podLogs:
         namespace: ($namespace)
+        selector: app.kubernetes.io/instance=test-dolphinscheduler
     - podLogs:
         selector: app.kubernetes.io/component=master
         tail: -1

--- a/test/e2e/ldap/chainsaw-test.yaml
+++ b/test/e2e/ldap/chainsaw-test.yaml
@@ -58,5 +58,7 @@ spec:
     - describe:
         apiVersion: v1
         kind: Pod
+        selector: app.kubernetes.io/instance=test-dolphinscheduler
     - podLogs:
         namespace: ($namespace)
+        selector: app.kubernetes.io/instance=test-dolphinscheduler

--- a/test/e2e/pdb/chainsaw-test.yaml
+++ b/test/e2e/pdb/chainsaw-test.yaml
@@ -54,7 +54,7 @@ spec:
     - describe:
         apiVersion: v1
         kind: Pod
-        namespace: '*'
+        selector: app.kubernetes.io/instance=test-dolphinscheduler
     - describe:
         apiVersion: apps/v1
         kind: StatefulSet

--- a/test/e2e/vector/chainsaw-test.yaml
+++ b/test/e2e/vector/chainsaw-test.yaml
@@ -44,5 +44,7 @@ spec:
     - describe:
         apiVersion: v1
         kind: Pod
+        selector: app.kubernetes.io/instance=test-dolphinscheduler
     - podLogs:
         namespace: ($namespace)
+        selector: app.kubernetes.io/instance=test-dolphinscheduler


### PR DESCRIPTION
## Summary

Fixes Chainsaw Test failures across all 13 open PRs.

## Root Causes

### 1. Master OOMKilled (primary failure)
- **File:** `internal/controller/master/role.go`
- Master component hardcodes `JAVA_OPTS: -Xms1g -Xmx1g -Xmn512m`
- Default memory limit is `800Mi` (`internal/common/config.go`)
- JVM heap (1GB) exceeds container memory limit (800Mi) → OOMKilled
- Master pod restart loop → StatefulSet never ready → assert timeout

### 2. Chainsaw 1.35 breaking change (secondary error in catch blocks)
- **Files:** `test/e2e/*/chainsaw-test.yaml`
- `describe` and `podLogs` operations without `name` or `selector`
- Chainsaw 1.35 now requires explicit name/selector, was optional before
- Only triggered when assert fails (catch block)

## Changes

1. **Master JAVA_OPTS:** `-Xms1g -Xmx1g -Xmn512m` → `-Xms512m -Xmx512m -Xmn256m`
   - Matches API and Alerter which already use 512m settings
   - Fits within 800Mi container limit

2. **Test catch blocks:** Add `selector: app.kubernetes.io/instance=test-dolphinscheduler` to `describe` and `podLogs` operations in:
   - `test/e2e/default/chainsaw-test.yaml`
   - `test/e2e/ldap/chainsaw-test.yaml`
   - `test/e2e/pdb/chainsaw-test.yaml`
   - `test/e2e/vector/chainsaw-test.yaml`

## Impact
This fixes Chainsaw Test (1.35.0) failures for all 13 affected open PRs (#218-#238).