### PR TITLE
fix(ci): increase cleanup timeout to 240s and add forceTerminationGracePeriod

### DIFF
--- a/test/e2e/.chainsaw.yaml
+++ b/test/e2e/.chainsaw.yaml
@@ -7,10 +7,11 @@ spec:
   timeouts:
     apply: 300s
     assert: 600s
-    cleanup: 120s
+    cleanup: 240s
     delete: 120s
     error: 180s
     exec: 300s
   # skipDelete: true
   failFast: true
+  forceTerminationGracePeriod: 10s
   parallel: 1


### PR DESCRIPTION
## Summary

The smoke-observability chainsaw test cleanup phase timed out at 120s when deleting
namespace with DolphinScheduler + Prometheus + ZooKeeper + PostgreSQL pods (Java apps
have slow graceful termination).

## Changes
- Increase cleanup timeout from 120s to 240s
- Add forceTerminationGracePeriod: 10s to force kill pods stuck in termination

## Testing
- [x] Verified other operators (zookeeper, hbase, kafka, hive) use similar or higher values