### PR TITLE
fix(ci): increase cleanup timeout to 240s and add forceTerminationGracePeriod

### DIFF
--- a/test/e2e/.chainsaw.yaml
+++ b/test/e2e/.chainsaw.yaml
@@ -7,10 +7,11 @@ spec:
   timeouts:
     apply: 300s
     assert: 600s
-    cleanup: 120s
+    cleanup: 240s
     delete: 120s
     error: 180s
     exec: 300s
   # skipDelete: true
   failFast: true
+  forceTerminationGracePeriod: 10s
   parallel: 1


### PR DESCRIPTION
## Summary

Same fix as release-0.4: smoke-observability chainsaw test cleanup timed out at 120s
when deleting namespace with heavy Java workloads. Sync to main so future release
branches inherit the fix.

## Changes
- Increase cleanup timeout from 120s to 240s
- Add forceTerminationGracePeriod: 10s

## Testing
- [x] Verified other operators use similar or higher values