### PR TITLE
fix(ci): split chart-lint-test into chart-lint-helm and chart-e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
         run: ah lint
 
 
-  chart-lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -253,50 +253,42 @@ jobs:
       - name: Create kind cluster
         if: steps.check-changes.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.check-changes.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/dolphinscheduler-operator:$VERSION
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/dolphinscheduler-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           ct install \
             --since "${{ steps.commit-range.outputs.since_commit }}" \
             --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
             --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-            zookeeper-operator
-          )
+  chart-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install dolphinscheduler-operator chart
-          helm install --create-namespace --namespace dolphinscheduler-operators --wait dolphinscheduler-operator ./deploy/helm/dolphinscheduler-operator
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
-
+      - name: Run chart-e2e
+        run: make chart-e2e
 
   release-chart:
     name: Release Chart
@@ -304,7 +296,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - chart-linter-artifacthub
-      - chart-lint-test
+      - chart-lint-helm
+      - chart-e2e
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -155,10 +155,13 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 chart: manifests kustomize ## Generate helm chart for the operator.
 	$(KUSTOMIZE) build config/crd > deploy/helm/$(PROJECT_NAME)/crds/crds.yaml
 
-.PHONY: chart-publish ## Publish helm chart for the operator.
-chart-publish: helm chart ## Publish helm chart for the operator.
+.PHONY: helm-chart-package ## Package helm chart for the operator.
+helm-chart-package: helm chart ## Package helm chart for the operator.
 	mkdir -p target/charts
 	$(HELM) package deploy/helm/$(PROJECT_NAME) --version $(VERSION) --app-version $(VERSION) --destination target/charts
+
+.PHONY: chart-publish ## Publish helm chart for the operator.
+chart-publish: helm-chart-package ## Publish helm chart for the operator.
 	$(HELM) push target/charts/$(PROJECT_NAME)-$(VERSION).tgz $(OCI_REGISTRY)
 
 
@@ -346,3 +349,11 @@ chainsaw-test: chainsaw ## Run the chainsaw test
 chainsaw-cleanup: ## Run the chainsaw cleanup
 	KUBECONFIG=$(KIND_KUBECONFIG) make helm-uninstall-depends
 	KUBECONFIG=$(KIND_KUBECONFIG) make undeploy
+
+.PHONY: chart-e2e
+chart-e2e: kind-create chainsaw-setup helm-chart-package ## Run e2e tests with Helm chart deployment
+	$(KIND) --name $(KIND_CLUSTER_NAME) load docker-image $(IMG)
+	$(HELM) upgrade --install --create-namespace --namespace $(PROJECT_NAME) \
+		--kubeconfig $(KIND_KUBECONFIG) --wait $(PROJECT_NAME) \
+		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
+	KUBECONFIG=$(KIND_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/


### PR DESCRIPTION
## What this PR does

Splits the monolithic `chart-lint-test` job in `release.yml` into two independent jobs, aligning with the structure used in zookeeper-operator and other kubedoop operators.

### Changes

**`.github/workflows/release.yml`:**
- Replace `chart-lint-test` job with:
  - `chart-lint-helm`: helm lint + chart-testing install (ct install)
  - `chart-e2e`: end-to-end tests via `make chart-e2e`
- Update `release-chart` job `needs` to reference the two new jobs

**`Makefile`:**
- Add `helm-chart-package` target (extracted from `chart-publish` for reuse)
- Add `chart-e2e` target: kind-create → chainsaw-setup → helm-chart-package → chainsaw e2e
- `chart-publish` now depends on `helm-chart-package`

### Reference
- Follows the pattern established in [zookeeper-operator](https://github.com/zncdatadev/zookeeper-operator/blob/main/.github/workflows/release.yml)
- The 5/23 Release CI run (ID 26336657160) was manually cancelled with chainsaw tests failing due to the monolithic job structure